### PR TITLE
Add a working example for custom directives

### DIFF
--- a/examples/custom-directives/README.md
+++ b/examples/custom-directives/README.md
@@ -1,0 +1,95 @@
+# custom-directive
+
+This directory contains a simple GraphQL with custom directives example based on `graphql-yoga`.
+
+## Get started
+
+**Clone the repository:**
+
+```sh
+git clone https://github.com/graphcool/graphql-yoga/
+cd graphql-yoga/examples/custom-directives
+```
+
+**Install dependencies and run the app:**
+
+```sh
+yarn install # or npm install
+yarn start   # or npm start
+```
+
+## Testing
+
+Open your browser at [http://localhost:4000](http://localhost:4000) and start sending queries.
+
+**Query `hello`:**
+
+```graphql
+query {
+  hello
+}
+```
+
+The server returns the following response:
+
+```json
+{
+  "data": {
+    "hello": "HELLO WORD"
+  }
+}
+```
+
+Note that the original `Hello Word` output from the resolver is now in upper case due to our custom `@upper` directive.
+
+**Query `secret` (with role set as `admin`):**
+```graphql
+query {
+  secret
+}
+```
+
+The server returns the following response:
+
+```json
+{
+  "data": {
+    "secret": "This is very secret"
+  }
+}
+```
+
+
+**Query `secret` (with role set as `user`):**
+
+Go to `index.js:45`, change `admin` by `user` and reload the server.
+
+```graphql
+query {
+  secret
+}
+```
+
+The server returns the following response:
+
+```json
+{
+  "data": {
+    "secret": null
+  },
+  "errors": [
+    {
+      "message": "You are not authorized. Expected roles: admin",
+      "locations": [
+        {
+          "line": 1,
+          "column": 2
+        }
+      ],
+      "path": [
+        "secret"
+      ]
+    }
+  ]
+}
+```

--- a/examples/custom-directives/index.js
+++ b/examples/custom-directives/index.js
@@ -1,0 +1,48 @@
+const { GraphQLServer } = require("graphql-yoga");
+
+const typeDefs = `
+  directive @upper on FIELD_DEFINITION
+  directive @auth(roles: [String]) on FIELD_DEFINITION
+
+  type Query {
+    hello: String! @upper
+    secret: String @auth(roles: ["admin"])
+  }
+`;
+
+const directiveResolvers = {
+  upper(next, src, args, context) {
+    return next().then(str => str.toUpperCase());
+  },
+  auth(next, src, args, context) {
+    const { roles } = context; // We asume has roles of current user in context;
+    const expectedRoles = args.roles || [];
+    if (
+      expectedRoles.length === 0 || expectedRoles.some(r => roles.includes(r))
+    ) {
+      // Call next to continues process resolver.
+      return next();
+    }
+
+    // We has two options here. throw an error or return null (if field is nullable).
+    throw new Error(
+      `You are not authorized. Expected roles: ${expectedRoles.join(", ")}`
+    );
+  }
+};
+
+const resolvers = {
+  Query: {
+    hello: () => `Hello World`,
+    secret: () => `This is very secret`
+  }
+};
+
+const server = new GraphQLServer({
+  typeDefs,
+  resolvers,
+  directiveResolvers,
+  context: () => ({ roles: ["admin"] })
+});
+
+server.start(() => console.log("Server is running on localhost:4000"));

--- a/examples/custom-directives/package.json
+++ b/examples/custom-directives/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "start": "node ."
+  },
+  "dependencies": {
+    "graphql-yoga": "1.2.0"
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import {
   GraphQLTypeResolver,
   ValidationContext,
 } from 'graphql'
-import { IDirectiveResolvers } from 'graphql-tools'
+import { IDirectiveResolvers } from 'graphql-tools/dist/Interfaces'
 import { SubscriptionOptions } from 'graphql-subscriptions/dist/subscriptions-manager'
 import { LogFunction } from 'apollo-server-core'
 


### PR DESCRIPTION
Hello,

Just add a simple example to your [custom directives pull-request](https://github.com/graphcool/graphql-yoga/pull/152) 😉 

I've just find a little fix for the `IDirectiveResolvers` type, that is not directly exported in the `index` file of graphql-tools, otherwise it works as expected.